### PR TITLE
e2e: add tests to exercise topology manager

### DIFF
--- a/tests/sriov/run-topology-manager-e2e.sh
+++ b/tests/sriov/run-topology-manager-e2e.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -x
+
+if [ ! -d "origin" ]; then
+	# up until the e2e tests are merged upstream, we need to use fromani's fork
+	git clone https://github.com/fromanirh/origin.git
+fi
+
+pushd origin
+# this branch contains the stable patches which will be part of PRs against
+# openshift/origin
+git checkout topomgr-e2e-tests-ci
+# up until all the tests are merged, we need to make sure we always pull
+# the latest fixes and tests.
+git pull --rebase
+
+# build 'openshift-tests' binary
+make WHAT=cmd/openshift-tests
+
+OPENSHIFT_TESTS=$(realpath ./_output/local/bin/linux/amd64/openshift-tests)
+
+$OPENSHIFT_TESTS run openshift/conformance --dry-run | \
+	grep -E "TopologyManager" | \
+	$OPENSHIFT_TESTS run -f -


### PR DESCRIPTION
bootstrap the process adding initial tests.
We will add more tests in the coming days.
This is the same code which is being submitted as PR
to openshift origin, currently under review and discussion.

The tests are still being actively developed
hence we track a specific (stable) branch and we update
it before each run.

Signed-off-by: Francesco Romani <fromani@redhat.com>