### PR TITLE
tests: topology: use reservedSystemCPUs

### DIFF
--- a/tests/topology/templates/4.3-performance.yaml
+++ b/tests/topology/templates/4.3-performance.yaml
@@ -45,6 +45,7 @@ spec:
      cpuManagerPolicy: static
      cpuManagerReconcilePeriod: 5s
      topologyManagerPolicy: single-numa-node
+     reservedSystemCPUs: 1,3,5,7
 
 #---
 #apiVersion: machineconfiguration.openshift.io/v1

--- a/tests/topology/templates/performance.yaml
+++ b/tests/topology/templates/performance.yaml
@@ -47,3 +47,4 @@ spec:
      cpuManagerPolicy: static
      cpuManagerReconcilePeriod: 5s
      topologyManagerPolicy: single-numa-node
+     reservedSystemCPUs: 1,3,5,7


### PR DESCRIPTION
recent 4.3 and 4.4 releases gained support for the kubelet flag
`reservedSystemCPUs` which allows the cluster admin to select
which CPU should be reserved for system tasks (e.g. running kubelet
itself!) to save cpu cores for exclusive allocation.

We make use to this option to avoid reserving CPUs on NUMA node 0,
which is most often the one on which PCI devices are attached to.

This allows us to test for full NUMA node allocation avoiding false
negatives.

Signed-off-by: Francesco Romani <fromani@redhat.com>