### PR TITLE
topomgr: tests merged in the master branch

### DIFF
--- a/tests/sriov/topology-manager-e2e.sh
+++ b/tests/sriov/topology-manager-e2e.sh
@@ -2,17 +2,10 @@
 set -x
 
 if [ ! -d "origin" ]; then
-	# up until the e2e tests are merged upstream, we need to use fromani's fork
-	git clone https://github.com/fromanirh/origin.git
+	git clone https://github.com/openshift/origin.git
 fi
 
 pushd origin
-# this branch contains the stable patches which will be part of PRs against
-# openshift/origin
-git checkout topomgr-e2e-tests-ci
-# up until all the tests are merged, we need to make sure we always pull
-# the latest fixes and tests.
-git pull --rebase
 
 # build 'openshift-tests' binary
 make WHAT=cmd/openshift-tests

--- a/tests/topology/topology-manager-e2e.sh
+++ b/tests/topology/topology-manager-e2e.sh
@@ -2,20 +2,13 @@
 set -x
 
 if [ ! -d "origin" ]; then
-	# up until the e2e tests are merged upstream, we need to use fromani's fork
-	git clone https://github.com/fromanirh/origin.git
+	git clone https://github.com/openshift/origin.git
 fi
 
 # create sriov network before pushd origin folder
 oc create -f templates/sn-intel.yaml
 
 pushd origin
-# this branch contains the stable patches which will be part of PRs against
-# openshift/origin
-git checkout topomgr-e2e-tests-ci
-# up until all the tests are merged, we need to make sure we always pull
-# the latest fixes and tests.
-git pull --rebase
 
 # build 'openshift-tests' binary
 make WHAT=cmd/openshift-tests


### PR DESCRIPTION
the Topology Manager e2e tests have been merged in the
openshift origin master branch: there is no more need
to use fromani's fork

CAUTION: caches (`origin` directory) need to be deleted before
to merge this patch.

Signed-off-by: Francesco Romani <fromani@redhat.com>