### PR TITLE
topology manager: temporary pull from fromani fork

### DIFF
--- a/tests/sriov/topology-manager-e2e.sh
+++ b/tests/sriov/topology-manager-e2e.sh
@@ -2,10 +2,14 @@
 set -x
 
 if [ ! -d "origin" ]; then
-	git clone https://github.com/openshift/origin.git
+	git clone https://github.com/fromanirh/origin.git
 fi
 
 pushd origin
+# fetch the fix to be submitted to openshift
+git checkout e2e-tm-fix-concurrent-creation-test
+# make sure to pull the last changes
+git pull --rebase
 
 # build 'openshift-tests' binary
 make WHAT=cmd/openshift-tests

--- a/tests/topology/topology-manager-e2e.sh
+++ b/tests/topology/topology-manager-e2e.sh
@@ -2,13 +2,17 @@
 set -x
 
 if [ ! -d "origin" ]; then
-	git clone https://github.com/openshift/origin.git
+	git clone https://github.com/fromanirh/origin.git
 fi
 
 # create sriov network before pushd origin folder
 oc create -f templates/sn-intel.yaml
 
 pushd origin
+# fetch the fix to be submitted to openshift
+git checkout e2e-tm-fix-concurrent-creation-test
+# make sure to pull the last changes
+git pull --rebase
 
 # build 'openshift-tests' binary
 make WHAT=cmd/openshift-tests


### PR DESCRIPTION
We discovered a TM e2e test is broken. To merge the fix,
we need to try out in a suitable 4.5 environment, so we pull
it here to validate it - we can't make things worse for jobs
already broken.

When the fix will be merged we can revert and pull from openshift master
again.

Signed-off-by: Francesco Romani <fromani@redhat.com>